### PR TITLE
Add PRD and roadmap documents

### DIFF
--- a/Beta_Ready_Checklist.md
+++ b/Beta_Ready_Checklist.md
@@ -1,0 +1,13 @@
+# Beta-Ready Checklist
+
+Use this list to confirm all pieces are in place for a public beta release.
+
+- [ ] Review and finalize the Product Requirements Document (PRD).
+- [ ] Validate the Roadmap milestones align with current features.
+- [ ] Smoke-test the GUI on Windows, macOS and Linux.
+- [ ] Ensure `ModelTrainer` handles missing target columns gracefully.
+- [ ] Verify model saving/loading works through the GUI and CLI.
+- [ ] Document setup instructions for required dependencies.
+- [ ] Run `pytest -q` and confirm all tests pass.
+- [ ] Tag a `v0.2-beta` release and update CHANGELOG (if present).
+

--- a/PRD.md
+++ b/PRD.md
@@ -1,0 +1,33 @@
+# Product Requirements Document (PRD)
+
+## Overview
+This project delivers a lightweight desktop application for experimenting with machine-learning models. It exposes a simple PyQt interface and a command line script that share a common `ModelTrainer` component.
+
+## Goals
+- Allow non-technical users to load a dataset (CSV or Excel) and train a variety of models with minimal setup.
+- Support quick experimentation with common algorithms: linear regression, random forest, SVM, PPO reinforcement learning and a basic LSTM.
+- Keep the training pipeline easy to extend and understand so contributors can add new models or preprocessing steps.
+
+## Non-Goals
+- Full production deployment or large-scale data management.
+- Advanced hyperparameter tuning or deep experiment tracking.
+
+## Functional Requirements
+- Desktop GUI to load a dataset, configure a model and view results.
+- Command line script `LSTM_Model_Trainer` for headless training.
+- Data preprocessing: drop missing values and dummy-encode categoricals.
+- Evaluation metrics displayed after training and optional cross-validation.
+- Ability to save trained models to disk.
+- Minimal unit tests verifying the `ModelTrainer` logic and imports.
+
+## Non-Functional Requirements
+- Python 3.8+ environment with PyQt5, pandas, scikit-learn, tensorflow and joblib installed.
+- Code should run on Windows/Linux/macOS with minimal modification.
+- Keep external dependencies lightweight and avoid network access during tests.
+
+## Acceptance Criteria
+- Users can train a model via the GUI without the interface freezing.
+- The command line script outputs evaluation metrics in JSON format.
+- Tests run successfully using `pytest -q` with stubbed dependencies.
+- Documentation covers setup, usage and testing procedures.
+

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,22 @@
+# Project Roadmap
+
+This roadmap outlines upcoming milestones for the LSTM Model Trainer.
+
+## v0.1 – Initial Release
+- Basic GUI for loading datasets and training standard models.
+- `ModelTrainer` module with preprocessing and evaluation utilities.
+- Example LSTM training script.
+- Minimal unit tests and documentation.
+
+## v0.2 – Beta
+- Improved error handling and logging in GUI and `ModelTrainer`.
+- Support saving and loading trained models through the GUI.
+- Cross-platform packaging instructions.
+- Expanded tests for edge cases.
+
+## v1.0 – Stable
+- Polish user experience and provide more flexible hyperparameter settings.
+- Optional hyperparameter tuning framework integration.
+- Additional visualization tools (e.g., confusion matrices, loss curves).
+- Continuous integration setup for automated testing.
+

--- a/Sprint_Plan.md
+++ b/Sprint_Plan.md
@@ -1,0 +1,28 @@
+# Sprint Plan – Next Development Cycle
+
+This sprint covers approximately two weeks of work aimed at preparing the beta release.
+
+## Goals
+- Close outstanding issues from the Beta-Ready Checklist.
+- Improve cross-platform packaging instructions.
+- Enhance unit test coverage for error conditions.
+
+## Tasks
+1. **Update Documentation**
+   - Finalize PRD and Roadmap.
+   - Write step-by-step setup guide in the README.
+2. **GUI Polishing**
+   - Add error messages for invalid dataset paths or target columns.
+   - Implement file dialogs for saving/loading models.
+3. **Testing**
+   - Expand `tests/test_model_trainer_core.py` with additional edge cases.
+   - Verify the GUI launches on Windows and Linux with sample data.
+4. **Packaging**
+   - Research PyInstaller configuration for building standalone binaries.
+   - Document packaging steps in a new `PACKAGING.md` file.
+
+## Deliverables
+- Updated documentation and checklist
+- Passing test suite (`pytest -q`)
+- Draft packaging instructions
+


### PR DESCRIPTION
## Summary
- add initial Product Requirements Document (PRD)
- sketch upcoming milestones in `ROADMAP.md`
- list beta-readiness tasks
- outline sprint plan for next development cycle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ec8a179348329acd50a494aa78ca9